### PR TITLE
Refactor: UUID

### DIFF
--- a/app/EloquentUser.php
+++ b/app/EloquentUser.php
@@ -4,8 +4,8 @@ namespace App;
 
 use App\Models\EloquentPost;
 use Domain\SSN\Auth\Entity\User;
+use GoldSpecDigital\LaravelEloquentUUID\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 class EloquentUser extends Authenticatable
@@ -20,7 +20,7 @@ class EloquentUser extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'id', 'name', 'email', 'password',
     ];
 
     /**
@@ -44,6 +44,7 @@ class EloquentUser extends Authenticatable
     public static function createFromUser(User $user)
     {
         (new self())
+            ->setAttribute('id', $user->getId()->toString())
             ->setAttribute('username', $user->getUsername())
             ->setAttribute('email', $user->getEmail())
             ->setAttribute('password', $user->getPassword())

--- a/app/Http/Controllers/Post/CreatePostController.php
+++ b/app/Http/Controllers/Post/CreatePostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Post;
 
+use App\EloquentUser;
 use App\Http\Controllers\Controller;
 use Domain\SSN\Auth\Entity\User;
 use Domain\SSN\Posts\Gateway\PostGateway;
@@ -11,6 +12,7 @@ use Domain\SSN\Posts\UseCases\CreatePost\CreatePostRequest;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Ramsey\Uuid\Uuid;
 
 class CreatePostController extends Controller
 {
@@ -42,12 +44,13 @@ class CreatePostController extends Controller
      */
     public function __invoke(Request $request)
     {
-        /** @var \App\EloquentUser $loggedUser */
+        /** @var EloquentUser $loggedUser */
         $loggedUser = $this->auth->guard()->user();
 
         $this->useCase->execute(new CreatePostRequest(
             $request->get('content'),
             new User(
+                Uuid::fromString($loggedUser->id),
                 $loggedUser->username,
                 $loggedUser->email,
                 $loggedUser->password

--- a/app/Models/EloquentPost.php
+++ b/app/Models/EloquentPost.php
@@ -12,6 +12,7 @@ class EloquentPost extends Model
     protected $table = "posts";
 
     protected $fillable = [
+        'id',
         'content'
     ];
 
@@ -19,6 +20,7 @@ class EloquentPost extends Model
     {
         $author = EloquentUser::where('email', $post->getAuthor()->getEmail())->first();
         $author->posts()->create([
+            'id' => $post->getId(),
             'content' => $post->getContent()
         ]);
     }

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -6,6 +6,7 @@ use App\EloquentUser;
 use Domain\SSN\Auth\Entity\User;
 use Domain\SSN\Auth\Exceptions\UserNotFoundException;
 use Domain\SSN\Auth\Gateway\UserGateway;
+use Ramsey\Uuid\Uuid;
 
 class UserRepository extends BaseRepository implements UserGateway
 {
@@ -22,6 +23,7 @@ class UserRepository extends BaseRepository implements UserGateway
 
         if ($dbUser) {
             return new User(
+                Uuid::fromString($dbUser->id),
                 $dbUser->username,
                 $dbUser->email,
                 $dbUser->password

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "beberlei/assert": "^3.2",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
+        "goldspecdigital/laravel-eloquent-uuid": "^7.0",
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "^7.24",
         "laravel/sanctum": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3c9adee6f7dd47beeb95e1e10f250cd",
+    "content-hash": "94cb89e7520f4aaa3f570d799a94c90d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -613,6 +613,63 @@
                 }
             ],
             "time": "2020-05-31T07:30:16+00:00"
+        },
+        {
+            "name": "goldspecdigital/laravel-eloquent-uuid",
+            "version": "v7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/goldspecdigital/laravel-eloquent-uuid.git",
+                "reference": "36fb8ee2092f96c02edbdef72bdc80b29fa83680"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/goldspecdigital/laravel-eloquent-uuid/zipball/36fb8ee2092f96c02edbdef72bdc80b29fa83680",
+                "reference": "36fb8ee2092f96c02edbdef72bdc80b29fa83680",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^7.0",
+                "php": "^7.2.5"
+            },
+            "require-dev": {
+                "ext-pdo": "*",
+                "friendsofphp/php-cs-fixer": "^2.15",
+                "orchestra/testbench": "^5.0",
+                "phpunit/phpunit": "^8.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "GoldSpecDigital\\LaravelEloquentUUID\\UuidServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GoldSpecDigital\\LaravelEloquentUUID\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Inamdar",
+                    "email": "matt@goldspecdigital.com"
+                }
+            ],
+            "description": "A simple drop-in solution for providing UUID support for the IDs of your Eloquent models.",
+            "homepage": "https://github.com/goldspecdigital/laravel-eloquent-uuid",
+            "keywords": [
+                "eloquent",
+                "laravel",
+                "php",
+                "uuid"
+            ],
+            "time": "2020-03-04T18:44:04+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Str;
 
 $factory->define(EloquentUser::class, function (Faker $faker) {
     return [
+        'id' => $faker->uuid,
         'username' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,7 +14,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->string('username');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/database/migrations/2020_09_01_163010_create_posts_table.php
+++ b/database/migrations/2020_09_01_163010_create_posts_table.php
@@ -14,7 +14,7 @@ class CreatePostsTable extends Migration
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->text('content');
             $table->unsignedInteger('user_id');
             $table->foreign('user_id')->references('id')->on('users')->onDelete('SET NULL');

--- a/domain/src/Auth/Entity/User.php
+++ b/domain/src/Auth/Entity/User.php
@@ -3,21 +3,26 @@
 namespace Domain\SSN\Auth\Entity;
 
 use Domain\SSN\Auth\UseCases\Registration\RegistrationRequest;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 class User
 {
+    private UuidInterface $id;
     private string $username;
     private string $email;
     private string $password;
 
     /**
      * User constructor.
+     * @param UuidInterface $id
      * @param string $username
      * @param string $email
      * @param string $password
      */
-    public function __construct(string $username, string $email, string $password)
+    public function __construct(UuidInterface $id, string $username, string $email, string $password)
     {
+        $this->id = $id;
         $this->username = $username;
         $this->email = $email;
         $this->password = $password;
@@ -26,10 +31,19 @@ class User
     public static function createFromRegistration(RegistrationRequest $request)
     {
         return new self(
+            Uuid::uuid4(),
             $request->getUsername(),
             $request->getEmail(),
             password_hash($request->getPlainPassword(), PASSWORD_ARGON2ID)
         );
+    }
+
+    /**
+     * @return UuidInterface
+     */
+    public function getId()
+    {
+        return $this->id;
     }
 
     /**

--- a/domain/src/Auth/UseCases/Registration/Registration.php
+++ b/domain/src/Auth/UseCases/Registration/Registration.php
@@ -31,11 +31,7 @@ class Registration
         $user = User::createFromRegistration($request);
         $this->gateway->registers($user);
 
-        $response = new RegistrationResponse(new User(
-            $request->getUsername(),
-            $request->getEmail(),
-            $request->getPlainPassword()
-        ));
+        $response = new RegistrationResponse($user);
         $presenter->presents($response);
     }
 }

--- a/domain/src/Posts/Entity/Post.php
+++ b/domain/src/Posts/Entity/Post.php
@@ -4,26 +4,43 @@ namespace Domain\SSN\Posts\Entity;
 
 use Domain\SSN\Auth\Entity\User;
 use Domain\SSN\Posts\UseCases\CreatePost\CreatePostRequest;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 class Post
 {
+    private UuidInterface $id;
     private User $author;
     private string $content;
 
     /**
      * Post constructor.
+     * @param UuidInterface $id
      * @param string $content
      * @param User $author
      */
-    public function __construct(string $content, User $author)
+    public function __construct(UuidInterface $id, string $content, User $author)
     {
+        $this->id = $id;
         $this->content = $content;
         $this->author = $author;
     }
 
     public static function createFromRequest(CreatePostRequest $request)
     {
-        return new self($request->getContent(), $request->getUser());
+        return new self(
+            Uuid::uuid4(),
+            $request->getContent(),
+            $request->getUser()
+        );
+    }
+
+    /**
+     * @return UuidInterface
+     */
+    public function getId(): UuidInterface
+    {
+        return $this->id;
     }
 
     /**

--- a/domain/tests/Adapters/Repositories/UserRepository.php
+++ b/domain/tests/Adapters/Repositories/UserRepository.php
@@ -5,6 +5,7 @@ namespace Domain\Tests\Adapters\Repositories;
 use Domain\SSN\Auth\Entity\User;
 use Domain\SSN\Auth\Exceptions\UserNotFoundException;
 use Domain\SSN\Auth\Gateway\UserGateway;
+use Ramsey\Uuid\Uuid;
 
 class UserRepository implements UserGateway
 {
@@ -26,11 +27,17 @@ class UserRepository implements UserGateway
     /**
      * @param string $email
      * @return User
+     * @throws UserNotFoundException
      */
     public function getUserByEmail(string $email): User
     {
         if ($email == 'good@domain.tld') {
-            return new User("username", $email, password_hash('correctPassword', PASSWORD_ARGON2ID));
+            return new User(
+                Uuid::uuid4(),
+                "username",
+                $email,
+                password_hash('correctPassword', PASSWORD_ARGON2ID)
+            );
         }
 
         foreach ($this->users as $user) {

--- a/domain/tests/Posts/CreatePostTest.php
+++ b/domain/tests/Posts/CreatePostTest.php
@@ -12,6 +12,7 @@ use Domain\SSN\Posts\UseCases\CreatePost\CreatePostRequest;
 use Domain\SSN\Posts\UseCases\CreatePost\CreatePostResponse;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
 
 class CreatePostTest extends TestCase
 {
@@ -39,6 +40,7 @@ class CreatePostTest extends TestCase
         };
 
         $this->user = new User(
+            Uuid::uuid4(),
             "AuthorName",
             "author@email.tld",
             "plainPassword"
@@ -79,7 +81,7 @@ class CreatePostTest extends TestCase
 
     public function invalidData(): Generator
     {
-        yield ["", new User('name', 'email@email.tld', 'password')];
+        yield ["", new User(Uuid::uuid4(), 'name', 'email@email.tld', 'password')];
         yield ["Some Content", null];
     }
 }

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -40,6 +40,7 @@ class LoginTest extends TestCase
 
     public function testFails()
     {
+        $this->withoutExceptionHandling();
         // Test initialization
         $credentials = [
             'email' => 'bad@domain.tld',

--- a/tests/Feature/Post/CreatePostTest.php
+++ b/tests/Feature/Post/CreatePostTest.php
@@ -13,6 +13,7 @@ class CreatePostTest extends TestCase
 
     public function testSuccessful()
     {
+        $this->withoutExceptionHandling();
         // Test initialization
         $this->actingAs($user = factory(EloquentUser::class)->create());
         $postInputs = factory(EloquentPost::class)->raw();


### PR DESCRIPTION
Using UUID instead of default auto-incrementing keys make the domain more independent from the infrastructure. It generates itself the IDs of the entities and it makes it easier now to implement features that need the ID in the request parameters.